### PR TITLE
Support dynamic form for aws_cloudwatch_event_target

### DIFF
--- a/cmd/tenco/main.go
+++ b/cmd/tenco/main.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	defaultOffset    = -9
-	defaultGenerator = &tenco.JsonGenerator{}
+	defaultGenerator = &tenco.JSONGenerator{}
 )
 
 func main() {

--- a/config.go
+++ b/config.go
@@ -1,111 +1,13 @@
 package tenco
 
-import (
-	"fmt"
-	"strings"
-)
-
 type Config struct {
 	Events []*ConfigEvent `yaml:"events"`
 }
 
 type ConfigEvent struct {
-	Name                  string                `yaml:"name"`
-	Description           string                `yaml:"description"`
-	Schedule              Schedule              `yaml:"schedule"`
-	CloudwatchEventTarget CloudwatchEventTarget `yaml:"cloudwatch_event_target"`
-	ContainerOverrides    []ContainerOverride   `yaml:"container_overrides"`
-	IsEnabled             bool                  `yaml:"is_enabled"`
-}
-
-func (c ConfigEvent) ContainerOverridesWithEnv(addEnvs []Environment) []ContainerOverride {
-	ret := make([]ContainerOverride, 0, len(c.ContainerOverrides))
-	for _, co := range c.ContainerOverrides {
-		ret = append(ret, ContainerOverride{
-			Name:        co.Name,
-			Command:     co.Command,
-			Environment: append(co.Environment, addEnvs...),
-		})
-	}
-	return ret
-}
-
-type CloudwatchEventTarget struct {
-	Arn       string    `yaml:"arn"        json:"arn"`
-	Rule      string    `yaml:"-"          json:"rule"`
-	RoleArn   string    `yaml:"role_arn"   json:"role_arn"`
-	ECSTarget ECSTarget `yaml:"ecs_target" json:"ecs_target"`
-}
-
-type ECSTarget struct {
-	LaunchType           string               `yaml:"launch_type"           json:"launch_type"`
-	PlatformVersion      string               `yaml:"platform_version"      json:"platform_version"`
-	TaskDefinitionArn    string               `yaml:"task_definition_arn"   json:"task_definition_arn"`
-	NetworkConfiguration NetworkConfiguration `yaml:"network_configuration" json:"network_configuration"`
-}
-
-type NetworkConfiguration struct {
-	Subnets        *StringWithArray `yaml:"subnets"          json:"subnets"`
-	SecurityGroups *StringWithArray `yaml:"security_groups"  json:"security_groups"`
-	AssignPublicIP bool             `yaml:"assign_public_ip" json:"assign_public_ip"`
-}
-
-type ContainerOverride struct {
-	Name        string        `json:"name"`
-	Command     []string      `json:"command"`
-	Environment []Environment `json:"environment"`
-}
-
-type containerOverride struct {
-	Name        string        `yaml:"name"`
-	Entrypoint  []string      `yaml:"entrypoint"`
-	Command     []string      `yaml:"command"`
-	Environment []Environment `yaml:"environment"`
-}
-
-type Environment struct {
-	Name  string `yaml:"name"  json:"name"`
-	Value string `yaml:"value" json:"value"`
-}
-
-func (c *ContainerOverride) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var ret containerOverride
-	if err := unmarshal(&ret); err != nil {
-		return err
-	}
-	c.Name = ret.Name
-	c.Command = append(ret.Entrypoint, ret.Command...)
-	c.Environment = ret.Environment
-	return nil
-}
-
-type StringWithArray struct {
-	String string
-	Array  []string
-}
-
-func (s *StringWithArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var ret interface{}
-	if err := unmarshal(&ret); err != nil {
-		return err
-	}
-
-	switch t := ret.(type) {
-	case string:
-		s.String = t
-	case []interface{}:
-		for _, v := range t {
-			s.Array = append(s.Array, v.(string))
-		}
-	default:
-		return fmt.Errorf("Unexpected parse error. %v", ret)
-	}
-	return nil
-}
-
-func (s *StringWithArray) MarshalJSON() ([]byte, error) {
-	if len(s.Array) == 0 {
-		return []byte(fmt.Sprintf(`"%s"`, s.String)), nil
-	}
-	return []byte(fmt.Sprintf(`["%s"]`, strings.Join(s.Array, `","`))), nil
+	Name                  string                 `yaml:"name"`
+	Description           string                 `yaml:"description"`
+	Schedule              Schedule               `yaml:"schedule"`
+	CloudwatchEventTarget map[string]interface{} `yaml:"cloudwatch_event_target"`
+	IsEnabled             bool                   `yaml:"is_enabled"`
 }

--- a/example/example.tf.json
+++ b/example/example.tf.json
@@ -35,88 +35,83 @@
     "aws_cloudwatch_event_target": {
       "hello-world-0": {
         "arn": "${data.aws_ecs_cluster.default.arn}",
-        "rule": "${aws_cloudwatch_event_rule.hello-world-0.name}",
-        "role_arn": "${data.aws_iam_role.ecsEventsRole.arn}",
         "ecs_target": {
           "launch_type": "FARGATE",
-          "platform_version": "1.4.0",
-          "task_definition_arn": "arn:aws:ecs:ap-northeast-1:${data.aws_caller_identity.current.account_id}:task-definition/${data.aws_ecs_task_definition.hello-world.family}",
           "network_configuration": {
-            "subnets": "${data.aws_subnet_ids.public.ids}",
+            "assign_public_ip": true,
             "security_groups": "${data.aws_security_groups.internal.ids}",
-            "assign_public_ip": true
-          }
+            "subnets": "${data.aws_subnet_ids.public.ids}"
+          },
+          "platform_version": "1.4.0",
+          "task_definition_arn": "arn:aws:ecs:ap-northeast-1:${data.aws_caller_identity.current.account_id}:task-definition/${data.aws_ecs_task_definition.hello-world.family}"
         },
-        "target_id": "hello-world",
-        "input": "{\"containerOverrides\":[{\"name\":\"hello-world\",\"command\":[\"time\",\"/bin/ash\",\"-c\",\"echo $MESSAGE\"],\"environment\":[{\"name\":\"MESSAGE\",\"value\":\"hello-world\"},{\"name\":\"CRON_SCHEDULE\",\"value\":\"0 0 ? * MON-FRI *\"},{\"name\":\"CRON_DESCRIPTION\",\"value\":\"hello-world\"}]}]}"
+        "input": "{\n  \"containerOverrides\": [\n    {\n      \"name\":       \"hello-world\",\n      \"entrypoint\": [\"time\"],\n      \"command\":    [\"/bin/ash\", \"-c\", \"echo $MESSAGE\"],\n      \"environment\" [\n        {\n          \"name\":  \"MESSAGE\",\n          \"value\": \"hello-world\"\n        }\n      ]\n    }\n  ]\n}",
+        "role_arn": "${data.aws_iam_role.ecsEventsRole.arn}",
+        "rule": "${aws_cloudwatch_event_rule.hello-world-0.name}"
       },
       "hello-world-1": {
         "arn": "${data.aws_ecs_cluster.default.arn}",
-        "rule": "${aws_cloudwatch_event_rule.hello-world-1.name}",
-        "role_arn": "${data.aws_iam_role.ecsEventsRole.arn}",
         "ecs_target": {
           "launch_type": "FARGATE",
-          "platform_version": "1.4.0",
-          "task_definition_arn": "arn:aws:ecs:ap-northeast-1:${data.aws_caller_identity.current.account_id}:task-definition/${data.aws_ecs_task_definition.hello-world.family}",
           "network_configuration": {
-            "subnets": "${data.aws_subnet_ids.public.ids}",
+            "assign_public_ip": true,
             "security_groups": "${data.aws_security_groups.internal.ids}",
-            "assign_public_ip": true
-          }
+            "subnets": "${data.aws_subnet_ids.public.ids}"
+          },
+          "platform_version": "1.4.0",
+          "task_definition_arn": "arn:aws:ecs:ap-northeast-1:${data.aws_caller_identity.current.account_id}:task-definition/${data.aws_ecs_task_definition.hello-world.family}"
         },
-        "target_id": "hello-world",
-        "input": "{\"containerOverrides\":[{\"name\":\"hello-world\",\"command\":[\"time\",\"/bin/ash\",\"-c\",\"echo $MESSAGE\"],\"environment\":[{\"name\":\"MESSAGE\",\"value\":\"hello-world\"},{\"name\":\"CRON_SCHEDULE\",\"value\":\"0 0 ? * MON-FRI *\"},{\"name\":\"CRON_DESCRIPTION\",\"value\":\"hello-world\"}]}]}"
+        "input": "{\n  \"containerOverrides\": [\n    {\n      \"name\":       \"hello-world\",\n      \"entrypoint\": [\"time\"],\n      \"command\":    [\"/bin/ash\", \"-c\", \"echo $MESSAGE\"],\n      \"environment\" [\n        {\n          \"name\":  \"MESSAGE\",\n          \"value\": \"hello-world\"\n        }\n      ]\n    }\n  ]\n}",
+        "role_arn": "${data.aws_iam_role.ecsEventsRole.arn}",
+        "rule": "${aws_cloudwatch_event_rule.hello-world-1.name}"
       },
       "hello-world-2": {
         "arn": "${data.aws_ecs_cluster.default.arn}",
-        "rule": "${aws_cloudwatch_event_rule.hello-world-2.name}",
-        "role_arn": "${data.aws_iam_role.ecsEventsRole.arn}",
         "ecs_target": {
           "launch_type": "FARGATE",
-          "platform_version": "1.4.0",
-          "task_definition_arn": "arn:aws:ecs:ap-northeast-1:${data.aws_caller_identity.current.account_id}:task-definition/${data.aws_ecs_task_definition.hello-world.family}",
           "network_configuration": {
-            "subnets": "${data.aws_subnet_ids.public.ids}",
+            "assign_public_ip": true,
             "security_groups": "${data.aws_security_groups.internal.ids}",
-            "assign_public_ip": true
-          }
+            "subnets": "${data.aws_subnet_ids.public.ids}"
+          },
+          "platform_version": "1.4.0",
+          "task_definition_arn": "arn:aws:ecs:ap-northeast-1:${data.aws_caller_identity.current.account_id}:task-definition/${data.aws_ecs_task_definition.hello-world.family}"
         },
-        "target_id": "hello-world",
-        "input": "{\"containerOverrides\":[{\"name\":\"hello-world\",\"command\":[\"time\",\"/bin/ash\",\"-c\",\"echo $MESSAGE\"],\"environment\":[{\"name\":\"MESSAGE\",\"value\":\"hello-world\"},{\"name\":\"CRON_SCHEDULE\",\"value\":\"0 0 ? * MON-FRI *\"},{\"name\":\"CRON_DESCRIPTION\",\"value\":\"hello-world\"}]}]}"
+        "input": "{\n  \"containerOverrides\": [\n    {\n      \"name\":       \"hello-world\",\n      \"entrypoint\": [\"time\"],\n      \"command\":    [\"/bin/ash\", \"-c\", \"echo $MESSAGE\"],\n      \"environment\" [\n        {\n          \"name\":  \"MESSAGE\",\n          \"value\": \"hello-world\"\n        }\n      ]\n    }\n  ]\n}",
+        "role_arn": "${data.aws_iam_role.ecsEventsRole.arn}",
+        "rule": "${aws_cloudwatch_event_rule.hello-world-2.name}"
       },
       "hello-world-3": {
         "arn": "${data.aws_ecs_cluster.default.arn}",
-        "rule": "${aws_cloudwatch_event_rule.hello-world-3.name}",
-        "role_arn": "${data.aws_iam_role.ecsEventsRole.arn}",
         "ecs_target": {
           "launch_type": "FARGATE",
-          "platform_version": "1.4.0",
-          "task_definition_arn": "arn:aws:ecs:ap-northeast-1:${data.aws_caller_identity.current.account_id}:task-definition/${data.aws_ecs_task_definition.hello-world.family}",
           "network_configuration": {
-            "subnets": "${data.aws_subnet_ids.public.ids}",
+            "assign_public_ip": true,
             "security_groups": "${data.aws_security_groups.internal.ids}",
-            "assign_public_ip": true
-          }
+            "subnets": "${data.aws_subnet_ids.public.ids}"
+          },
+          "platform_version": "1.4.0",
+          "task_definition_arn": "arn:aws:ecs:ap-northeast-1:${data.aws_caller_identity.current.account_id}:task-definition/${data.aws_ecs_task_definition.hello-world.family}"
         },
-        "target_id": "hello-world",
-        "input": "{\"containerOverrides\":[{\"name\":\"hello-world\",\"command\":[\"time\",\"/bin/ash\",\"-c\",\"echo $MESSAGE\"],\"environment\":[{\"name\":\"MESSAGE\",\"value\":\"hello-world\"},{\"name\":\"CRON_SCHEDULE\",\"value\":\"0 0 ? * MON-FRI *\"},{\"name\":\"CRON_DESCRIPTION\",\"value\":\"hello-world\"}]}]}"
+        "input": "{\n  \"containerOverrides\": [\n    {\n      \"name\":       \"hello-world\",\n      \"entrypoint\": [\"time\"],\n      \"command\":    [\"/bin/ash\", \"-c\", \"echo $MESSAGE\"],\n      \"environment\" [\n        {\n          \"name\":  \"MESSAGE\",\n          \"value\": \"hello-world\"\n        }\n      ]\n    }\n  ]\n}",
+        "role_arn": "${data.aws_iam_role.ecsEventsRole.arn}",
+        "rule": "${aws_cloudwatch_event_rule.hello-world-3.name}"
       },
       "hello-world-4": {
         "arn": "${data.aws_ecs_cluster.default.arn}",
-        "rule": "${aws_cloudwatch_event_rule.hello-world-4.name}",
-        "role_arn": "${data.aws_iam_role.ecsEventsRole.arn}",
         "ecs_target": {
           "launch_type": "FARGATE",
-          "platform_version": "1.4.0",
-          "task_definition_arn": "arn:aws:ecs:ap-northeast-1:${data.aws_caller_identity.current.account_id}:task-definition/${data.aws_ecs_task_definition.hello-world.family}",
           "network_configuration": {
-            "subnets": "${data.aws_subnet_ids.public.ids}",
+            "assign_public_ip": true,
             "security_groups": "${data.aws_security_groups.internal.ids}",
-            "assign_public_ip": true
-          }
+            "subnets": "${data.aws_subnet_ids.public.ids}"
+          },
+          "platform_version": "1.4.0",
+          "task_definition_arn": "arn:aws:ecs:ap-northeast-1:${data.aws_caller_identity.current.account_id}:task-definition/${data.aws_ecs_task_definition.hello-world.family}"
         },
-        "target_id": "hello-world",
-        "input": "{\"containerOverrides\":[{\"name\":\"hello-world\",\"command\":[\"time\",\"/bin/ash\",\"-c\",\"echo $MESSAGE\"],\"environment\":[{\"name\":\"MESSAGE\",\"value\":\"hello-world\"},{\"name\":\"CRON_SCHEDULE\",\"value\":\"0 0 ? * MON-FRI *\"},{\"name\":\"CRON_DESCRIPTION\",\"value\":\"hello-world\"}]}]}"
+        "input": "{\n  \"containerOverrides\": [\n    {\n      \"name\":       \"hello-world\",\n      \"entrypoint\": [\"time\"],\n      \"command\":    [\"/bin/ash\", \"-c\", \"echo $MESSAGE\"],\n      \"environment\" [\n        {\n          \"name\":  \"MESSAGE\",\n          \"value\": \"hello-world\"\n        }\n      ]\n    }\n  ]\n}",
+        "role_arn": "${data.aws_iam_role.ecsEventsRole.arn}",
+        "rule": "${aws_cloudwatch_event_rule.hello-world-4.name}"
       }
     }
   }

--- a/example/example.yml
+++ b/example/example.yml
@@ -1,26 +1,20 @@
 anchors:
-  entrypoint_default: &entrypoint_default [
-    "time"
-  ]
-  cloudwatch_event_targets_default: &cloudwatch_event_targets_default
-    arn:      ${data.aws_ecs_cluster.default.arn}
-    role_arn: ${data.aws_iam_role.ecsEventsRole.arn}
-    ecs_target:
-      launch_type:         FARGATE
-      platform_version:    1.4.0
-      task_definition_arn: 'arn:aws:ecs:ap-northeast-1:${data.aws_caller_identity.current.account_id}:task-definition/${data.aws_ecs_task_definition.hello-world.family}'
-      network_configuration:
-        subnets:          ${data.aws_subnet_ids.public.ids}
-#       subnets:
-#         - subnet_id
-#         - subnet_id
-#         - ...
-        security_groups:  ${data.aws_security_groups.internal.ids}
-#       security_groups:
-#         - security_group_id
-#         - security_group_id
-#         - ...
-        assign_public_ip: true
+  ecs_target_default: &ecs_target_default
+    launch_type:         FARGATE
+    platform_version:    1.4.0
+    task_definition_arn: 'arn:aws:ecs:ap-northeast-1:${data.aws_caller_identity.current.account_id}:task-definition/${data.aws_ecs_task_definition.hello-world.family}'
+    network_configuration:
+      subnets:          ${data.aws_subnet_ids.public.ids}
+#     subnets:
+#       - subnet_id
+#       - subnet_id
+#       - ...
+      security_groups:  ${data.aws_security_groups.internal.ids}
+#     security_groups:
+#       - security_group_id
+#       - security_group_id
+#       - ...
+      assign_public_ip: true
 
 events:
   - name: hello-world
@@ -31,11 +25,24 @@ events:
       minutes:      0
       hours:        0
       day_of_weeks: MON-FRI
-    cloudwatch_event_target: *cloudwatch_event_targets_default
-    container_overrides:
-      - name:       hello-world
-        entrypoint: *entrypoint_default
-        command:    ["/bin/ash", "-c", "echo $MESSAGE"]
-        environment:
-          - name:  MESSAGE
-            value: hello-world
+    cloudwatch_event_target:
+      arn:      ${data.aws_ecs_cluster.default.arn}
+      role_arn: ${data.aws_iam_role.ecsEventsRole.arn}
+      ecs_target: *ecs_target_default
+      input: |-
+        {
+          "containerOverrides": [
+            {
+              "name":       "hello-world",
+              "entrypoint": ["time"],
+              "command":    ["/bin/ash", "-c", "echo $MESSAGE"],
+              "environment" [
+                {
+                  "name":  "MESSAGE",
+                  "value": "hello-world"
+                }
+              ]
+            }
+          ]
+        }
+

--- a/generator.go
+++ b/generator.go
@@ -4,71 +4,62 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"reflect"
 )
 
 type Generator interface {
 	Generate(w io.Writer, conf Config, offset int) error
 }
 
-type JsonGenerator struct {
+type JSONGenerator struct {
 }
 
-func (g *JsonGenerator) Generate(w io.Writer, conf Config, offset int) error {
-	v := map[string]map[string]map[string]interface{}{
-		"resource": {
-			"aws_cloudwatch_event_rule":   {},
-			"aws_cloudwatch_event_target": {},
-		},
-	}
+func (g *JSONGenerator) Generate(w io.Writer, conf Config, offset int) error {
 	type EventRule struct {
 		Name               string `json:"name"`
 		Description        string `json:"description"`
 		ScheduleExpression string `json:"schedule_expression"`
 		IsEnabled          bool   `json:"is_enabled"`
 	}
-	type EventTarget struct {
-		CloudwatchEventTarget
-		TargetID string `json:"target_id"`
-		Input    string `json:"input"`
+	type Resource struct {
+		AWSCloudWatchEventRule   map[string]EventRule              `json:"aws_cloudwatch_event_rule"`
+		AWSCloudWatchEventTarget map[string]map[string]interface{} `json:"aws_cloudwatch_event_target"`
+	}
+
+	r := Resource{
+		AWSCloudWatchEventRule:   map[string]EventRule{},
+		AWSCloudWatchEventTarget: map[string]map[string]interface{}{},
 	}
 	for _, event := range conf.Events {
 		for i, expr := range event.Schedule.CronExprs(offset) {
 			eventName := fmt.Sprintf("%s-%d", event.Name, i)
-			v["resource"]["aws_cloudwatch_event_rule"][eventName] = EventRule{
+			r.AWSCloudWatchEventRule[eventName] = EventRule{
 				Name:               eventName,
 				Description:        fmt.Sprintf("%s\norig cron(%s)", event.Description, event.Schedule.OrigSchedule),
 				ScheduleExpression: fmt.Sprintf("cron(%s)", expr),
 				IsEnabled:          event.IsEnabled,
 			}
-			input := map[string][]ContainerOverride{
-				"containerOverrides": event.ContainerOverridesWithEnv([]Environment{
-					{
-						Name:  "CRON_SCHEDULE",
-						Value: event.Schedule.OrigSchedule.String(),
-					},
-					{
-						Name:  "CRON_DESCRIPTION",
-						Value: event.Description,
-					},
-				}),
-			}
-			b, err := json.Marshal(input)
-			if err != nil {
-				return fmt.Errorf("event.ContainerOverride json Marshal failed. %w", err)
-			}
-			v["resource"]["aws_cloudwatch_event_target"][eventName] = EventTarget{
-				CloudwatchEventTarget: CloudwatchEventTarget{
-					Arn:       event.CloudwatchEventTarget.Arn,
-					Rule:      fmt.Sprintf("${aws_cloudwatch_event_rule.%s.name}", eventName),
-					RoleArn:   event.CloudwatchEventTarget.RoleArn,
-					ECSTarget: event.CloudwatchEventTarget.ECSTarget,
-				},
-				TargetID: event.Name,
-				Input:    string(b),
-			}
+			event.CloudwatchEventTarget["rule"] = fmt.Sprintf("${aws_cloudwatch_event_rule.%s.name}", eventName)
+			r.AWSCloudWatchEventTarget[eventName] = convertMapToKeyString(event.CloudwatchEventTarget).(map[string]interface{})
 		}
+	}
+	v := map[string]Resource{
+		"resource": r,
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(v)
+}
+
+func convertMapToKeyString(v interface{}) interface{} {
+	tv := reflect.TypeOf(v)
+	if tv.Kind() != reflect.Map {
+		return v
+	}
+	vv := reflect.ValueOf(v)
+	rv := make(map[string]interface{}, vv.Len())
+	for _, mk := range vv.MapKeys() {
+		rv[fmt.Sprintf("%s", mk.Interface())] = convertMapToKeyString(vv.MapIndex(mk).Interface())
+	}
+	return rv
 }


### PR DESCRIPTION
従来のECS Targetの他にもAWS CloudWatch Eventsのtargetには様々な値が設定できるため、自由に入力できるようにしました
以前あった`containerOverrides`に関してはinputを個別に入力することで対応できると考えています。
なお、これは互換性を壊す変更です。ご検討の程よろしくおねがいします

参考: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target