### PR TITLE
cwでないcronに入れても大丈夫そうなものに入力を絞ったり出力したり

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,13 @@
+name: test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - uses: actions/checkout@v2
+      - run: go test -v ./...

--- a/cron_expr.go
+++ b/cron_expr.go
@@ -19,7 +19,7 @@ func (c CWCronExpr) String() string {
 	} else {
 		var tmp []string
 		for _, v := range c.Minutes {
-			if len(v) == 59 {
+			if len(v) == 60 {
 				tmp = append(tmp, "*")
 			} else if 1 < len(v) {
 				tmp = append(tmp, fmt.Sprintf("%d-%d", v[0], v[len(v)-1]))
@@ -79,7 +79,7 @@ func (c CronExpr) String() string {
 	} else {
 		var tmp []string
 		for _, v := range c.Minutes {
-			if len(v) == 59 {
+			if len(v) == 60 {
 				tmp = append(tmp, "*")
 			} else if 1 < len(v) {
 				tmp = append(tmp, fmt.Sprintf("%d-%d", v[0], v[len(v)-1]))

--- a/cron_expr.go
+++ b/cron_expr.go
@@ -6,16 +6,28 @@ import (
 	"strings"
 )
 
-type CronExpr struct {
-	Minutes   string
+type CWCronExpr struct {
+	Minutes   [][]int
 	Hours     [][]int
 	DayOfWeek int
 }
 
-func (c CronExpr) String() string {
-	m := c.Minutes
-	if m == "" {
+func (c CWCronExpr) String() string {
+	var m string
+	if len(c.Minutes) == 0 {
 		m = "*"
+	} else {
+		var tmp []string
+		for _, v := range c.Minutes {
+			if len(v) == 59 {
+				tmp = append(tmp, "*")
+			} else if 1 < len(v) {
+				tmp = append(tmp, fmt.Sprintf("%d-%d", v[0], v[len(v)-1]))
+			} else {
+				tmp = append(tmp, strconv.Itoa(v[0]))
+			}
+		}
+		m = strings.Join(tmp, ",")
 	}
 
 	var h string
@@ -52,4 +64,56 @@ func (c CronExpr) String() string {
 	year := "*"
 
 	return strings.Join([]string{m, h, day, month, dow, year}, " ")
+}
+
+type CronExpr struct {
+	Minutes   [][]int
+	Hours     [][]int
+	DayOfWeek int
+}
+
+func (c CronExpr) String() string {
+	var m string
+	if len(c.Minutes) == 0 {
+		m = "*"
+	} else {
+		var tmp []string
+		for _, v := range c.Minutes {
+			if len(v) == 59 {
+				tmp = append(tmp, "*")
+			} else if 1 < len(v) {
+				tmp = append(tmp, fmt.Sprintf("%d-%d", v[0], v[len(v)-1]))
+			} else {
+				tmp = append(tmp, strconv.Itoa(v[0]))
+			}
+		}
+		m = strings.Join(tmp, ",")
+	}
+
+	var h string
+	if len(c.Hours) == 0 {
+		h = "*"
+	} else {
+		var tmp []string
+		for _, v := range c.Hours {
+			if len(v) == 24 {
+				tmp = append(tmp, "*")
+			} else if 1 < len(v) {
+				tmp = append(tmp, fmt.Sprintf("%d-%d", v[0], v[len(v)-1]))
+			} else {
+				tmp = append(tmp, strconv.Itoa(v[0]))
+			}
+		}
+		h = strings.Join(tmp, ",")
+	}
+
+	day := "*"
+	month := "*"
+
+	dow := strconv.Itoa(c.DayOfWeek - 1)
+	if c.DayOfWeek == 0 {
+		dow = "*"
+	}
+
+	return strings.Join([]string{m, h, day, month, dow}, " ")
 }

--- a/cron_expr_test.go
+++ b/cron_expr_test.go
@@ -7,6 +7,17 @@ import (
 )
 
 func TestCWCronExpr(t *testing.T) {
+	minutesAsterisc := []int{
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+		10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+		20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+		30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+		40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+		50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+	}
+	hoursAsterisc := []int{
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+	}
 	cases := []struct {
 		cronExpr tenco.CWCronExpr
 		expect   string
@@ -15,6 +26,14 @@ func TestCWCronExpr(t *testing.T) {
 			cronExpr: tenco.CWCronExpr{
 				Minutes:   [][]int{},
 				Hours:     [][]int{},
+				DayOfWeek: 0,
+			},
+			expect: "* * * * ? *",
+		},
+		{
+			cronExpr: tenco.CWCronExpr{
+				Minutes:   [][]int{minutesAsterisc},
+				Hours:     [][]int{hoursAsterisc},
 				DayOfWeek: 0,
 			},
 			expect: "* * * * ? *",
@@ -60,6 +79,17 @@ func TestCWCronExpr(t *testing.T) {
 }
 
 func TestCronExpr(t *testing.T) {
+	minutesAsterisc := []int{
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+		10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+		20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+		30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+		40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+		50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+	}
+	hoursAsterisc := []int{
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+	}
 	cases := []struct {
 		cronExpr tenco.CronExpr
 		expect   string
@@ -68,6 +98,14 @@ func TestCronExpr(t *testing.T) {
 			cronExpr: tenco.CronExpr{
 				Minutes:   [][]int{},
 				Hours:     [][]int{},
+				DayOfWeek: 0,
+			},
+			expect: "* * * * *",
+		},
+		{
+			cronExpr: tenco.CronExpr{
+				Minutes:   [][]int{minutesAsterisc},
+				Hours:     [][]int{hoursAsterisc},
 				DayOfWeek: 0,
 			},
 			expect: "* * * * *",

--- a/cron_expr_test.go
+++ b/cron_expr_test.go
@@ -1,0 +1,113 @@
+package tenco_test
+
+import (
+	"testing"
+
+	"github.com/mix3/tenco"
+)
+
+func TestCWCronExpr(t *testing.T) {
+	cases := []struct {
+		cronExpr tenco.CWCronExpr
+		expect   string
+	}{
+		{
+			cronExpr: tenco.CWCronExpr{
+				Minutes:   [][]int{},
+				Hours:     [][]int{},
+				DayOfWeek: 0,
+			},
+			expect: "* * * * ? *",
+		},
+		{
+			cronExpr: tenco.CWCronExpr{
+				Minutes:   [][]int{{0}},
+				Hours:     [][]int{},
+				DayOfWeek: 0,
+			},
+			expect: "0 * * * ? *",
+		},
+		{
+			cronExpr: tenco.CWCronExpr{
+				Minutes:   [][]int{{0}},
+				Hours:     [][]int{{0}},
+				DayOfWeek: 0,
+			},
+			expect: "0 0 * * ? *",
+		},
+		{
+			cronExpr: tenco.CWCronExpr{
+				Minutes:   [][]int{{0, 1, 2}, {4, 5, 6}},
+				Hours:     [][]int{{0, 1, 2}, {4, 5, 6}},
+				DayOfWeek: 0,
+			},
+			expect: "0-2,4-6 0-2,4-6 * * ? *",
+		},
+		{
+			cronExpr: tenco.CWCronExpr{
+				Minutes:   [][]int{{0, 1, 2}, {4, 5, 6}},
+				Hours:     [][]int{{0, 1, 2}, {4, 5, 6}},
+				DayOfWeek: 1,
+			},
+			expect: "0-2,4-6 0-2,4-6 ? * 1 *",
+		},
+	}
+	for i, cc := range cases {
+		if got, want := cc.cronExpr.String(), cc.expect; got != want {
+			t.Errorf("[%d] test failed. want %q, but got %q", i, want, got)
+		}
+	}
+}
+
+func TestCronExpr(t *testing.T) {
+	cases := []struct {
+		cronExpr tenco.CronExpr
+		expect   string
+	}{
+		{
+			cronExpr: tenco.CronExpr{
+				Minutes:   [][]int{},
+				Hours:     [][]int{},
+				DayOfWeek: 0,
+			},
+			expect: "* * * * *",
+		},
+		{
+			cronExpr: tenco.CronExpr{
+				Minutes:   [][]int{{0}},
+				Hours:     [][]int{},
+				DayOfWeek: 0,
+			},
+			expect: "0 * * * *",
+		},
+		{
+			cronExpr: tenco.CronExpr{
+				Minutes:   [][]int{{0}},
+				Hours:     [][]int{{0}},
+				DayOfWeek: 0,
+			},
+			expect: "0 0 * * *",
+		},
+		{
+			cronExpr: tenco.CronExpr{
+				Minutes:   [][]int{{0, 1, 2}, {4, 5, 6}},
+				Hours:     [][]int{{0, 1, 2}, {4, 5, 6}},
+				DayOfWeek: 0,
+			},
+			expect: "0-2,4-6 0-2,4-6 * * *",
+		},
+		{
+			cronExpr: tenco.CronExpr{
+				Minutes:   [][]int{{0, 1, 2}, {4, 5, 6}},
+				Hours:     [][]int{{0, 1, 2}, {4, 5, 6}},
+				DayOfWeek: 1,
+			},
+			expect: "0-2,4-6 0-2,4-6 * * 0",
+		},
+	}
+	for i, cc := range cases {
+		if got, want := cc.cronExpr.String(), cc.expect; got != want {
+			t.Errorf("[%d] test failed. want %q, but got %q", i, want, got)
+		}
+	}
+}

--- a/generator.go
+++ b/generator.go
@@ -31,7 +31,7 @@ func (g *JSONGenerator) Generate(w io.Writer, conf Config, offset int) error {
 		AWSCloudWatchEventTarget: map[string]map[string]interface{}{},
 	}
 	for _, event := range conf.Events {
-		for i, expr := range event.Schedule.CronExprs(offset) {
+		for i, expr := range event.Schedule.CWCronExprs(offset) {
 			eventName := fmt.Sprintf("%s-%d", event.Name, i)
 			r.AWSCloudWatchEventRule[eventName] = EventRule{
 				Name:               eventName,

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -10,6 +10,14 @@ import (
 )
 
 func TestMinutes(t *testing.T) {
+	asterisc := tenco.Minutes{
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+		10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+		20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+		30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+		40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+		50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+	}
 	cases := []struct {
 		input  string
 		err    bool
@@ -32,28 +40,36 @@ func TestMinutes(t *testing.T) {
 			err:   true,
 		},
 		{
+			input: "*-4",
+			err:   true,
+		},
+		{
+			input: "*/0",
+			err:   true,
+		},
+		{
 			input:  "",
-			expect: tenco.Minutes(""),
+			expect: asterisc,
 		},
 		{
 			input:  "*",
-			expect: tenco.Minutes("*"),
+			expect: asterisc,
 		},
 		{
-			input:  "1/4",
-			expect: tenco.Minutes("1/4"),
+			input:  "3/12",
+			expect: tenco.Minutes{3, 15, 27, 39, 51},
 		},
 		{
 			input:  "1-4",
-			expect: tenco.Minutes("1-4"),
+			expect: tenco.Minutes{1, 2, 3, 4},
 		},
 		{
-			input:  "*-4",
-			expect: tenco.Minutes("*-4"),
+			input:  "*/9",
+			expect: tenco.Minutes{0, 9, 18, 27, 36, 45, 54},
 		},
 		{
-			input:  "*,*-4,*/9",
-			expect: tenco.Minutes("*,*-4,*/9"),
+			input:  "1,5-9,50/3",
+			expect: tenco.Minutes{1, 5, 6, 7, 8, 9, 50, 53, 56, 59},
 		},
 	}
 	for i, c := range cases {
@@ -78,6 +94,7 @@ func TestMinutes(t *testing.T) {
 }
 
 func TestHours(t *testing.T) {
+	asterisc := tenco.Hours{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}
 	cases := []struct {
 		input  string
 		err    bool
@@ -104,16 +121,20 @@ func TestHours(t *testing.T) {
 			err:   true,
 		},
 		{
-			input: "*/4",
+			input: "*/0",
 			err:   true,
 		},
 		{
+			input:  "*/4",
+			expect: tenco.Hours{0, 4, 8, 12, 16, 20},
+		},
+		{
 			input:  "",
-			expect: tenco.Hours{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
+			expect: asterisc,
 		},
 		{
 			input:  "*",
-			expect: tenco.Hours{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
+			expect: asterisc,
 		},
 		{
 			input:  "1,5,9",
@@ -222,6 +243,19 @@ func TestDayOfWeeks(t *testing.T) {
 }
 
 func TestCronExprs(t *testing.T) {
+	minutesAsterisc := [][]int{
+		{
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+			10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+			20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+			30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+			40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+			50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+		},
+	}
+	hoursAsterisc := [][]int{
+		{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
+	}
 	cases := []struct {
 		minutes    string
 		hours      string
@@ -237,10 +271,8 @@ func TestCronExprs(t *testing.T) {
 			offset:     0,
 			expect: []tenco.CronExpr{
 				{
-					Minutes: "",
-					Hours: [][]int{
-						{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
-					},
+					Minutes:   minutesAsterisc,
+					Hours:     hoursAsterisc,
 					DayOfWeek: 0,
 				},
 			},
@@ -252,7 +284,7 @@ func TestCronExprs(t *testing.T) {
 			offset:     0,
 			expect: []tenco.CronExpr{
 				{
-					Minutes: "",
+					Minutes: minutesAsterisc,
 					Hours: [][]int{
 						{0},
 					},
@@ -267,7 +299,9 @@ func TestCronExprs(t *testing.T) {
 			offset:     0,
 			expect: []tenco.CronExpr{
 				{
-					Minutes: "0",
+					Minutes: [][]int{
+						{0},
+					},
 					Hours: [][]int{
 						{0},
 					},
@@ -282,7 +316,7 @@ func TestCronExprs(t *testing.T) {
 			offset:     -9,
 			expect: []tenco.CronExpr{
 				{
-					Minutes: "",
+					Minutes: minutesAsterisc,
 					Hours: [][]int{
 						{15},
 					},
@@ -297,7 +331,9 @@ func TestCronExprs(t *testing.T) {
 			offset:     -9,
 			expect: []tenco.CronExpr{
 				{
-					Minutes: "0",
+					Minutes: [][]int{
+						{0},
+					},
 					Hours: [][]int{
 						{15},
 					},
@@ -312,18 +348,55 @@ func TestCronExprs(t *testing.T) {
 			offset:     -9,
 			expect: []tenco.CronExpr{
 				{
-					Minutes: "0",
+					Minutes: [][]int{
+						{0},
+					},
 					Hours: [][]int{
 						{23},
 					},
 					DayOfWeek: 1,
 				},
 				{
-					Minutes: "0",
+					Minutes: [][]int{
+						{0},
+					},
 					Hours: [][]int{
 						{0},
 					},
 					DayOfWeek: 2,
+				},
+			},
+		},
+		{
+			minutes: "55-5",
+			hours:   "",
+			offset:  -9,
+			expect: []tenco.CronExpr{
+				{
+					Minutes: [][]int{
+						{0, 1, 2, 3, 4, 5},
+						{55, 56, 57, 58, 59},
+					},
+					Hours:     hoursAsterisc,
+					DayOfWeek: 0,
+				},
+			},
+		},
+		{
+			minutes: "55-5",
+			hours:   "4-13",
+			offset:  -9,
+			expect: []tenco.CronExpr{
+				{
+					Minutes: [][]int{
+						{0, 1, 2, 3, 4, 5},
+						{55, 56, 57, 58, 59},
+					},
+					Hours: [][]int{
+						{0, 1, 2, 3, 4},
+						{19, 20, 21, 22, 23},
+					},
+					DayOfWeek: 0,
 				},
 			},
 		},
@@ -334,42 +407,46 @@ func TestCronExprs(t *testing.T) {
 			offset:     -9,
 			expect: []tenco.CronExpr{
 				{
-					Minutes: "0",
+					Minutes: [][]int{
+						{0},
+					},
 					Hours: [][]int{
 						{15, 16, 17, 18, 19, 20, 21, 22, 23},
 					},
 					DayOfWeek: 1,
 				},
 				{
-					Minutes: "0",
-					Hours: [][]int{
-						{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
+					Minutes: [][]int{
+						{0},
 					},
+					Hours:     hoursAsterisc,
 					DayOfWeek: 2,
 				},
 				{
-					Minutes: "0",
-					Hours: [][]int{
-						{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
+					Minutes: [][]int{
+						{0},
 					},
+					Hours:     hoursAsterisc,
 					DayOfWeek: 3,
 				},
 				{
-					Minutes: "0",
-					Hours: [][]int{
-						{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
+					Minutes: [][]int{
+						{0},
 					},
+					Hours:     hoursAsterisc,
 					DayOfWeek: 4,
 				},
 				{
-					Minutes: "0",
-					Hours: [][]int{
-						{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
+					Minutes: [][]int{
+						{0},
 					},
+					Hours:     hoursAsterisc,
 					DayOfWeek: 5,
 				},
 				{
-					Minutes: "0",
+					Minutes: [][]int{
+						{0},
+					},
 					Hours: [][]int{
 						{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14},
 					},


### PR DESCRIPTION
cw用ではないcron式が欲しそうな雰囲気を感じるので調整

- minutes はタイムゾーンの影響を受けないのでパースせずに文字列でそのまま持っていたが、cw ではない cron のときに困るのでパースするようにした
- `*-m` みたいな入力が cw では許されていたがイレギュラーだし cw ではない cron でも困るので絞った
- `*/0` みたいな入力が cw では許されていたがイレギュラーだし cw ではない cron でも困るので絞った
- hours で `*/m` な入力ができないようになってた（お漏らし）ので通すようにした
- cw 用ではない cron 式も出力出来るようにしてライブラリで使えるようにした