### PR TITLE
name,schedule省略したら怒るようにしたり、minutes,hours省略しても大丈夫なようにしたり

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,5 +1,9 @@
 package tenco
 
+import (
+	"fmt"
+)
+
 type Config struct {
 	Events []*ConfigEvent `yaml:"events"`
 }
@@ -7,7 +11,23 @@ type Config struct {
 type ConfigEvent struct {
 	Name                  string                 `yaml:"name"`
 	Description           string                 `yaml:"description"`
-	Schedule              Schedule               `yaml:"schedule"`
+	Schedule              *Schedule              `yaml:"schedule"`
 	CloudwatchEventTarget map[string]interface{} `yaml:"cloudwatch_event_target"`
 	IsEnabled             bool                   `yaml:"is_enabled"`
+}
+
+func (s *ConfigEvent) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type configEvent ConfigEvent
+	var ret configEvent
+	if err := unmarshal(&ret); err != nil {
+		return err
+	}
+	if ret.Name == "" {
+		return fmt.Errorf("Validation failed. field `name` required")
+	}
+	if ret.Schedule == nil {
+		return fmt.Errorf("Validation failed. field `schedule` required")
+	}
+	*s = ConfigEvent(ret)
+	return nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,55 @@
+package tenco_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mix3/tenco"
+	"gopkg.in/yaml.v2"
+)
+
+func TestEventConfig(t *testing.T) {
+	cases := []struct {
+		input string
+		err   string
+	}{
+		{
+			input: `
+schedule:
+  minutes: "0"
+  hours:   "0"
+`,
+			err: "Validation failed. field `name` required",
+		},
+		{
+			input: `
+name: test
+`,
+			err: "Validation failed. field `schedule` required",
+		},
+		{
+			input: `
+name: test
+schedule:
+  minutes: "0"
+  hours:   "0"
+`,
+		},
+	}
+	for i, c := range cases {
+		var ec tenco.ConfigEvent
+		err := yaml.Unmarshal([]byte(c.input), &ec)
+		if err != nil {
+			if c.err == "" {
+				t.Errorf("[%d] test failed. %s", i, err)
+			} else if !strings.Contains(err.Error(), c.err) {
+				t.Errorf("[%d] test failed. %q does not contain %q", i, err.Error(), c.err)
+			}
+			continue
+		}
+		if c.err != "" {
+			t.Errorf("[%d] test failed", i)
+			continue
+		}
+	}
+}

--- a/schedule.go
+++ b/schedule.go
@@ -9,16 +9,10 @@ import (
 )
 
 type Schedule struct {
-	Minutes      Minutes
-	Hours        Hours
-	DayOfWeeks   DayOfWeeks
-	OrigSchedule OrigSchedule
-}
-
-type schedule struct {
-	Minutes    Minutes    `yaml:"minutes"`
-	Hours      Hours      `yaml:"hours"`
-	DayOfWeeks DayOfWeeks `yaml:"day_of_weeks"`
+	Minutes      Minutes      `yaml:"minutes"`
+	Hours        Hours        `yaml:"hours"`
+	DayOfWeeks   DayOfWeeks   `yaml:"day_of_weeks"`
+	OrigSchedule OrigSchedule `yaml:"-"`
 }
 
 type OrigSchedule struct {
@@ -57,6 +51,7 @@ func (o OrigSchedule) String() string {
 }
 
 func (s *Schedule) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type schedule Schedule
 	var ret schedule
 	if err := unmarshal(&ret); err != nil {
 		return err
@@ -65,12 +60,8 @@ func (s *Schedule) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal(&orig); err != nil {
 		return err
 	}
-	*s = Schedule{
-		Minutes:      ret.Minutes,
-		Hours:        ret.Hours,
-		DayOfWeeks:   ret.DayOfWeeks,
-		OrigSchedule: orig,
-	}
+	ret.OrigSchedule = orig
+	*s = Schedule(ret)
 	return nil
 }
 

--- a/schedule.go
+++ b/schedule.go
@@ -56,6 +56,12 @@ func (s *Schedule) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal(&ret); err != nil {
 		return err
 	}
+	if len(ret.Minutes) == 0 {
+		ret.Minutes.asterisc()
+	}
+	if len(ret.Hours) == 0 {
+		ret.Hours.asterisc()
+	}
 	var orig OrigSchedule
 	if err := unmarshal(&orig); err != nil {
 		return err
@@ -181,6 +187,14 @@ func (ms Minutes) merge() [][]int {
 	return ret
 }
 
+func (ms *Minutes) asterisc() {
+	ret := make(Minutes, 60)
+	for i := Minute(0); i < 60; i++ {
+		ret[i] = i
+	}
+	*ms = ret
+}
+
 func (ms *Minutes) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	if err := unmarshal(&str); err != nil {
@@ -189,10 +203,7 @@ func (ms *Minutes) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	// "" "*" -> 0,1,2,...
 	if str == "" || str == "*" {
-		for i := 0; i < 60; i++ {
-			ms.add(i)
-		}
-		return nil
+		return nil // ScheduleのUnmarshalYAMLで埋めるのでここでは何もしない
 	}
 
 	for _, v := range strings.Split(str, ",") {
@@ -289,10 +300,7 @@ func (hs *Hours) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	// "" "*" -> 0,1,2,...
 	if str == "" || str == "*" {
-		for i := 0; i < 24; i++ {
-			hs.add(i)
-		}
-		return nil
+		return nil // ScheduleのUnmarshalYAMLで埋めるのでここでは何もしない
 	}
 
 	for _, v := range strings.Split(str, ",") {
@@ -404,6 +412,14 @@ func (hs Hours) merge() [][]int {
 	}
 	ret = append(ret, tmp)
 	return ret
+}
+
+func (hs *Hours) asterisc() {
+	ret := make(Hours, 24)
+	for i := Hour(0); i < 24; i++ {
+		ret[i] = i
+	}
+	*hs = ret
 }
 
 type DayOfWeek int

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -236,6 +236,149 @@ func TestDayOfWeeks(t *testing.T) {
 	}
 }
 
+func TestSchedule(t *testing.T) {
+	minutesAsterisc := tenco.Minutes{
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+		10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+		20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+		30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+		40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+		50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+	}
+	hoursAsterisc := tenco.Hours{
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+	}
+	cases := []struct {
+		input  string
+		expect tenco.Schedule
+	}{
+		{
+			input: `
+minutes:      ""
+`,
+			expect: tenco.Schedule{
+				Minutes:    minutesAsterisc,
+				Hours:      hoursAsterisc,
+				DayOfWeeks: nil,
+				OrigSchedule: tenco.OrigSchedule{
+					Minutes:    "",
+					Hours:      "",
+					DayOfWeeks: "",
+				},
+			},
+		},
+		{
+			input: `
+hours:        ""
+`,
+			expect: tenco.Schedule{
+				Minutes:    minutesAsterisc,
+				Hours:      hoursAsterisc,
+				DayOfWeeks: nil,
+				OrigSchedule: tenco.OrigSchedule{
+					Minutes:    "",
+					Hours:      "",
+					DayOfWeeks: "",
+				},
+			},
+		},
+		{
+			input: `
+day_of_weeks: ""
+`,
+			expect: tenco.Schedule{
+				Minutes:    minutesAsterisc,
+				Hours:      hoursAsterisc,
+				DayOfWeeks: nil,
+				OrigSchedule: tenco.OrigSchedule{
+					Minutes:    "",
+					Hours:      "",
+					DayOfWeeks: "",
+				},
+			},
+		},
+		{
+			input: `
+minutes:      ""
+hours:        ""
+day_of_weeks: ""
+`,
+			expect: tenco.Schedule{
+				Minutes:    minutesAsterisc,
+				Hours:      hoursAsterisc,
+				DayOfWeeks: nil,
+				OrigSchedule: tenco.OrigSchedule{
+					Minutes:    "",
+					Hours:      "",
+					DayOfWeeks: "",
+				},
+			},
+		},
+		{
+			input: `
+minutes:      "0"
+hours:        "0"
+day_of_weeks: "SUN"
+`,
+			expect: tenco.Schedule{
+				Minutes:    tenco.Minutes{0},
+				Hours:      tenco.Hours{0},
+				DayOfWeeks: tenco.DayOfWeeks{1},
+				OrigSchedule: tenco.OrigSchedule{
+					Minutes:    "0",
+					Hours:      "0",
+					DayOfWeeks: "SUN",
+				},
+			},
+		},
+		{
+			input: `
+minutes:      "0"
+hours:        "8,9"
+day_of_weeks: "MON"
+`,
+			expect: tenco.Schedule{
+				Minutes:    tenco.Minutes{0},
+				Hours:      tenco.Hours{8, 9},
+				DayOfWeeks: tenco.DayOfWeeks{2},
+				OrigSchedule: tenco.OrigSchedule{
+					Minutes:    "0",
+					Hours:      "8,9",
+					DayOfWeeks: "MON",
+				},
+			},
+		},
+		{
+			input: `
+minutes:      "55-5"
+hours:        "4-13"
+day_of_weeks: "MON-FRI"
+`,
+			expect: tenco.Schedule{
+				Minutes:    tenco.Minutes{55, 56, 57, 58, 59, 0, 1, 2, 3, 4, 5},
+				Hours:      tenco.Hours{4, 5, 6, 7, 8, 9, 10, 11, 12, 13},
+				DayOfWeeks: tenco.DayOfWeeks{2, 3, 4, 5, 6},
+				OrigSchedule: tenco.OrigSchedule{
+					Minutes:    "55-5",
+					Hours:      "4-13",
+					DayOfWeeks: "MON-FRI",
+				},
+			},
+		},
+	}
+	for i, c := range cases {
+		var s tenco.Schedule
+		err := yaml.Unmarshal([]byte(c.input), &s)
+		if err != nil {
+			t.Errorf("[%d] test failed. %s", i, err)
+			continue
+		}
+		if g, w := s, c.expect; !reflect.DeepEqual(g, w) {
+			t.Errorf("[%d] test faield. want %+v, but got %+v", i, w, g)
+		}
+	}
+}
+
 func TestCronExprs(t *testing.T) {
 	minutesAsterisc := [][]int{
 		{
@@ -251,18 +394,16 @@ func TestCronExprs(t *testing.T) {
 		{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
 	}
 	cases := []struct {
-		minutes    string
-		hours      string
-		dayOfWeeks string
-		offset     int
-		err        bool
-		expect     []tenco.CronExpr
+		input  string
+		offset int
+		err    bool
+		expect []tenco.CronExpr
 	}{
 		{
-			minutes:    "",
-			hours:      "",
-			dayOfWeeks: "",
-			offset:     0,
+			input: `
+minutes:      ""
+`,
+			offset: 0,
 			expect: []tenco.CronExpr{
 				{
 					Minutes:   minutesAsterisc,
@@ -272,10 +413,53 @@ func TestCronExprs(t *testing.T) {
 			},
 		},
 		{
-			minutes:    "",
-			hours:      "0",
-			dayOfWeeks: "",
-			offset:     0,
+			input: `
+hours:        ""
+`,
+			offset: 0,
+			expect: []tenco.CronExpr{
+				{
+					Minutes:   minutesAsterisc,
+					Hours:     hoursAsterisc,
+					DayOfWeek: 0,
+				},
+			},
+		},
+		{
+			input: `
+day_of_weeks: ""
+`,
+			offset: 0,
+			expect: []tenco.CronExpr{
+				{
+					Minutes:   minutesAsterisc,
+					Hours:     hoursAsterisc,
+					DayOfWeek: 0,
+				},
+			},
+		},
+		{
+			input: `
+minutes:      ""
+hours:        ""
+day_of_weeks: ""
+`,
+			offset: 0,
+			expect: []tenco.CronExpr{
+				{
+					Minutes:   minutesAsterisc,
+					Hours:     hoursAsterisc,
+					DayOfWeek: 0,
+				},
+			},
+		},
+		{
+			input: `
+minutes:      ""
+hours:        "0"
+day_of_weeks: ""
+`,
+			offset: 0,
 			expect: []tenco.CronExpr{
 				{
 					Minutes: minutesAsterisc,
@@ -287,10 +471,12 @@ func TestCronExprs(t *testing.T) {
 			},
 		},
 		{
-			minutes:    "0",
-			hours:      "0",
-			dayOfWeeks: "SUN",
-			offset:     0,
+			input: `
+minutes:      "0"
+hours:        "0"
+day_of_weeks: "SUN"
+`,
+			offset: 0,
 			expect: []tenco.CronExpr{
 				{
 					Minutes: [][]int{
@@ -304,10 +490,12 @@ func TestCronExprs(t *testing.T) {
 			},
 		},
 		{
-			minutes:    "",
-			hours:      "0",
-			dayOfWeeks: "",
-			offset:     -9,
+			input: `
+minutes:      ""
+hours:        "0"
+day_of_weeks: ""
+`,
+			offset: -9,
 			expect: []tenco.CronExpr{
 				{
 					Minutes: minutesAsterisc,
@@ -319,10 +507,12 @@ func TestCronExprs(t *testing.T) {
 			},
 		},
 		{
-			minutes:    "0",
-			hours:      "0",
-			dayOfWeeks: "SUN",
-			offset:     -9,
+			input: `
+minutes:      "0"
+hours:        "0"
+day_of_weeks: "SUN"
+`,
+			offset: -9,
 			expect: []tenco.CronExpr{
 				{
 					Minutes: [][]int{
@@ -336,10 +526,12 @@ func TestCronExprs(t *testing.T) {
 			},
 		},
 		{
-			minutes:    "0",
-			hours:      "8,9",
-			dayOfWeeks: "MON",
-			offset:     -9,
+			input: `
+minutes:      "0"
+hours:        "8,9"
+day_of_weeks: "MON"
+`,
+			offset: -9,
 			expect: []tenco.CronExpr{
 				{
 					Minutes: [][]int{
@@ -362,9 +554,11 @@ func TestCronExprs(t *testing.T) {
 			},
 		},
 		{
-			minutes: "55-5",
-			hours:   "",
-			offset:  -9,
+			input: `
+minutes:      "55-5"
+hours:        ""
+`,
+			offset: -9,
 			expect: []tenco.CronExpr{
 				{
 					Minutes: [][]int{
@@ -377,9 +571,11 @@ func TestCronExprs(t *testing.T) {
 			},
 		},
 		{
-			minutes: "55-5",
-			hours:   "4-13",
-			offset:  -9,
+			input: `
+minutes:      "55-5"
+hours:        "4-13"
+`,
+			offset: -9,
 			expect: []tenco.CronExpr{
 				{
 					Minutes: [][]int{
@@ -395,10 +591,11 @@ func TestCronExprs(t *testing.T) {
 			},
 		},
 		{
-			minutes:    "0",
-			hours:      "*",
-			dayOfWeeks: "MON-FRI",
-			offset:     -9,
+			input: `
+minutes:      "0"
+day_of_weeks: "MON-FRI"
+`,
+			offset: -9,
 			expect: []tenco.CronExpr{
 				{
 					Minutes: [][]int{
@@ -451,12 +648,7 @@ func TestCronExprs(t *testing.T) {
 	}
 	for i, c := range cases {
 		var s tenco.Schedule
-		input := fmt.Sprintf(`
-minutes:      "%s"
-hours:        "%s"
-day_of_weeks: "%s"
-`, c.minutes, c.hours, c.dayOfWeeks)
-		err := yaml.Unmarshal([]byte(input), &s)
+		err := yaml.Unmarshal([]byte(c.input), &s)
 		if err != nil {
 			if !c.err {
 				t.Errorf("[%d] test failed. %s", i, err)

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -82,9 +82,7 @@ func TestMinutes(t *testing.T) {
 			continue
 		}
 		if c.err {
-			if err == nil {
-				t.Errorf("[%d] test failed", i)
-			}
+			t.Errorf("[%d] test failed", i)
 			continue
 		}
 		if g, w := s.Minutes, c.expect; !reflect.DeepEqual(g, w) {
@@ -171,9 +169,7 @@ func TestHours(t *testing.T) {
 			continue
 		}
 		if c.err {
-			if err == nil {
-				t.Errorf("[%d] test failed", i)
-			}
+			t.Errorf("[%d] test failed", i)
 			continue
 		}
 		if g, w := s.Hours, c.expect; !reflect.DeepEqual(g, w) {
@@ -231,9 +227,7 @@ func TestDayOfWeeks(t *testing.T) {
 			continue
 		}
 		if c.err {
-			if err == nil {
-				t.Errorf("[%d] test failed", i)
-			}
+			t.Errorf("[%d] test failed", i)
 			continue
 		}
 		if g, w := s.DayOfWeeks, c.expect; !reflect.DeepEqual(g, w) {
@@ -470,9 +464,7 @@ day_of_weeks: "%s"
 			continue
 		}
 		if c.err {
-			if err == nil {
-				t.Errorf("[%d] test failed", i)
-			}
+			t.Errorf("[%d] test failed", i)
 			continue
 		}
 		if g, w := s.CronExprs(c.offset), c.expect; !reflect.DeepEqual(g, w) {


### PR DESCRIPTION
- 基本的に yaml の unmarshal で、カラム省略されると UnmarshalYAML を通らないので Minutes,Hours の UnmarshalYAML で空文字チェックで `*` 扱いにすることが出来ないことが分かった
  - schedule を省略したら Config の UnmarshalYAML で怒るようにして schedule を省略させないことにした
  - minutes,hours を省略されたら Schedule の UnmrashalYAML で空チェックして `*` 扱いすることにした
    - 具体的には `yaml に hours が存在しなかった場合、CronExprs() でpanicする` 事象の対応 
- ついでに name も省略したら怒るようにした
  - さすがに name は省略して欲しくないので
- 若干テストがおかしかったので追加したり修正したり